### PR TITLE
Feature/Connect to mongo db

### DIFF
--- a/ONWServices/Models/Game.cs
+++ b/ONWServices/Models/Game.cs
@@ -1,5 +1,6 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using ONWServices.Models.Serializers;
 using System;
 
 namespace ONWServices.Models
@@ -8,6 +9,7 @@ namespace ONWServices.Models
     public class Game : BaseDocument
     {
         [BsonElement("gameId")]
+        [BsonSerializer(typeof(GuidStringSerializer))]
         public Guid GameId { get; set; }
     }
 }

--- a/ONWServices/Models/Serializers/GuidStringSerializer.cs
+++ b/ONWServices/Models/Serializers/GuidStringSerializer.cs
@@ -1,0 +1,27 @@
+﻿using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using System;
+
+namespace ONWServices.Models.Serializers
+{
+    /// <summary>
+    /// Serializes <c>Guid</c>'s to <c>string</c>'s and back.
+    /// </summary>
+    /// <remarks>
+    /// The default <c>Guid</c> serializer, <c>MongoDB.Bson.Serialization.Serializers.GuidSerializer</c>,
+    /// serializes <c>Guid</c>'s as <c>byte</c> arrays. This class opts to serialize using the
+    /// much-more-readable <c>string</c> format.
+    /// </remarks>
+    public class GuidStringSerializer : SerializerBase<Guid>
+    {
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Guid value)
+        {
+            context.Writer.WriteString(value.ToString());
+        }
+
+        public override Guid Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            return new Guid(context.Reader.ReadString());
+        }
+    }
+}

--- a/ONWServices/Startup.cs
+++ b/ONWServices/Startup.cs
@@ -3,11 +3,16 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using ONWServices.Repositories;
+using ONWServices.Settings;
 
 namespace ONWServices
 {
     public class Startup
     {
+        private const string MONGODB_CONNECTION_STRING_SECTION_NAME = "MongoDb:ConnectionString";
+        private const string MONGODB_DATABASE_NAME_SECTION_NAME = "MongoDb:Database";
+
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -19,6 +24,17 @@ namespace ONWServices
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
+            services.Configure<MongoDbSettings>(
+                settings =>
+                {
+                    settings.ConnectionString = Configuration.GetSection(MONGODB_CONNECTION_STRING_SECTION_NAME).Value;
+                    settings.Database = Configuration.GetSection(MONGODB_DATABASE_NAME_SECTION_NAME).Value;
+                }
+            );
+            
+            services.AddSingleton<IOnwDbContext, OnwDbContext>();
+            services.AddSingleton<IGameRepository, GameRepository>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/ONWServices/appsettings.json
+++ b/ONWServices/appsettings.json
@@ -1,4 +1,8 @@
 {
+    "MongoDB": {
+        "ConnectionString": "mongodb://localhost:27017",
+        "Database": "onwdb"
+    },
     "Logging": {
         "LogLevel": {
             "Default": "Warning"


### PR DESCRIPTION
2 "major" changes here:

1. Serialize `Game.GameId` as a `string` (the default serializer the mongo driver uses sends 3 byte arrays for `Guid`'s but `string`'s are easier to read IMO).
2. Add mongodb configuration

Added `MongoDb:ConnectionString` and `MongoDb:Database` sections to the `appsettings.json` file, defaulting to `localhost` values (I totally stole that style from a helpful website, btw, but I like the style a lot).

On the production server, we can add environment variables `MongoDb__ConnectionString` and `MongoDb__Database` respectively to override the local values and connect to the real server. We can also add those values to a docker yaml file whenever we start using docker and control the connection string/database name that way.

Again, notice that no one is actually _using_ the `GameRepository` atm but this should complete the setup needed to start connecting to and using mongo. (I also added some test code to the controller to create a game and whatnot and it worked fine.)